### PR TITLE
add current def to current user if they add to new patient workflow

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -7,6 +7,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from .api import UserViewSet
 from .views import (
     CustomFieldDefinitionAssignedView,
+    CustomFieldDefinitionAssignView,
     CustomFieldDefinitionListCreateView,
     CustomFieldDefinitionRetrieveUpdateDeleteView,
     PatientCustomFieldListView,
@@ -51,6 +52,11 @@ urlpatterns = [
         "api/custom-field-definitions/<int:pk>/",
         CustomFieldDefinitionRetrieveUpdateDeleteView.as_view(),
         name="custom-field-definition-detail",
+    ),
+    path(
+        "api/custom-field-definitions/<int:pk>/assign/",
+        CustomFieldDefinitionAssignView.as_view(),
+        name="custom-field-definition-assign",
     ),
     # Patient custom field values endpoints
     path(

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -177,3 +177,25 @@ class PatientCustomFieldListView(generics.ListAPIView):
         return PatientCustomField.objects.filter(patient_id=patient_id).select_related(
             "field_definition"
         )
+
+
+class CustomFieldDefinitionAssignView(generics.GenericAPIView):
+    """
+    Handles assigning a custom field definition to the current user.
+    """
+
+    queryset = CustomFieldDefinition.objects.all()
+    serializer_class = CustomFieldDefinitionSerializer
+
+    def post(self, request, *args, **kwargs):
+        custom_field = self.get_object()
+        user = request.user
+        logger.info(f"Assigning custom field {custom_field.id} to user {user.email}")
+
+        try:
+            user.available_custom_fields.add(custom_field)
+            logger.info("Successfully assigned custom field to user")
+            return Response(status=status.HTTP_200_OK)
+        except Exception as e:
+            logger.error(f"Error assigning custom field to user: {e}")
+            raise

--- a/frontend/app/actions/get-custom-fields-action.ts
+++ b/frontend/app/actions/get-custom-fields-action.ts
@@ -91,3 +91,25 @@ export async function createCustomField(data: {
     throw error
   }
 }
+
+export async function assignCustomFieldToUser(
+  customFieldId: number
+): Promise<void> {
+  const session = await getServerSession(authOptions)
+  if (!session) {
+    throw new Error('You must be logged in to assign custom fields')
+  }
+
+  try {
+    console.log('Assigning custom field to user:', customFieldId)
+    const api = await getApiClient(session)
+    await api.request.request({
+      method: 'POST',
+      url: `/api/custom-field-definitions/${customFieldId}/assign/`
+    })
+    console.log('Successfully assigned custom field to user')
+  } catch (error) {
+    console.error('Error assigning custom field to user:', error)
+    throw error
+  }
+}

--- a/frontend/app/components/PatientForm.tsx
+++ b/frontend/app/components/PatientForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  assignCustomFieldToUser,
   createCustomField,
   getCustomFields,
   getUserCustomFields
@@ -162,6 +163,22 @@ export function PatientForm({ onSubmit, initialData }: PatientFormProps) {
       ) {
         console.log('Field already exists in form')
         return
+      }
+
+      // Check if field is not in user's assigned fields
+      if (!userAssignedFields.some((f) => f.id === selectedField.id)) {
+        console.log('Assigning field to user:', selectedField.id)
+        try {
+          await assignCustomFieldToUser(selectedField.id)
+          // Update user assigned fields
+          setUserAssignedFields((prev) => {
+            const updated = [selectedField, ...prev]
+            console.log('Updated user assigned fields:', updated)
+            return updated
+          })
+        } catch (error) {
+          console.error('Error assigning field to user:', error)
+        }
       }
 
       console.log(


### PR DESCRIPTION
This pull request introduces a new feature that allows users to assign custom field definitions to themselves. The changes span both backend and frontend code to support this functionality.

### Backend changes:

* Added a new view `CustomFieldDefinitionAssignView` to handle the assignment of custom field definitions to users. This includes defining the view in `backend/api/views.py` and adding the corresponding URL pattern in `backend/api/urls.py`. [[1]](diffhunk://#diff-585b0663a266246ad03c1bd2a7022a5a9b795b87285a64517115c2c18dbc8a09R180-R201) [[2]](diffhunk://#diff-b71791ed73586c27ac4f3bf9b030a6eb0d996495b22694beb80e87c44f5c5b2aR10) [[3]](diffhunk://#diff-b71791ed73586c27ac4f3bf9b030a6eb0d996495b22694beb80e87c44f5c5b2aR56-R60)

### Frontend changes:

* Added a new function `assignCustomFieldToUser` in `frontend/app/actions/get-custom-fields-action.ts` to make a POST request to the backend endpoint for assigning custom fields.
* Updated the `PatientForm` component to use the new `assignCustomFieldToUser` function, ensuring that custom fields are assigned to the user if they are not already assigned. [[1]](diffhunk://#diff-35241619bbe00287ea8eef7efcc0e2597ed67a2a135b6a01f7d8b8f2bb357b3aR4) [[2]](diffhunk://#diff-35241619bbe00287ea8eef7efcc0e2597ed67a2a135b6a01f7d8b8f2bb357b3aR168-R183)